### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/org.nickvision.application.gnome/resources/org.nickvision.application.metainfo.xml.in
+++ b/org.nickvision.application.gnome/resources/org.nickvision.application.metainfo.xml.in
@@ -28,7 +28,7 @@
   </provides>
   <releases>
     <release version="2024.3.0-next" date="2024-03-01">
-      <description translatable="no">
+      <description translate="no">
         <p>- Initial Release</p>
       </description>
     </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.