### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
     types: [ "review_requested", "ready_for_review" ]
 name: Spell Check
+permissions:
+  contents: read
 jobs:
   codespell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NickvisionApps/Application/security/code-scanning/1](https://github.com/NickvisionApps/Application/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow is performing a spell-checking operation, it likely only requires read access to the repository contents. We will add the `permissions` key at the root level of the workflow to apply the least privilege permissions (`contents: read`) to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
